### PR TITLE
新增path参数解析matcher

### DIFF
--- a/router/src/main/java/com/chenenyu/router/MatcherRegistry.java
+++ b/router/src/main/java/com/chenenyu/router/MatcherRegistry.java
@@ -4,6 +4,7 @@ import com.chenenyu.router.matcher.AbsMatcher;
 import com.chenenyu.router.matcher.BrowserMatcher;
 import com.chenenyu.router.matcher.DirectMatcher;
 import com.chenenyu.router.matcher.ImplicitMatcher;
+import com.chenenyu.router.matcher.RestfulParamsMatcher;
 import com.chenenyu.router.matcher.SchemeMatcher;
 
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public class MatcherRegistry {
     private static final List<AbsMatcher> registry = new ArrayList<>();
 
     static {
+        registry.add(new RestfulParamsMatcher(0x1001));
         registry.add(new DirectMatcher(0x1000));
         registry.add(new SchemeMatcher(0x0100));
         registry.add(new ImplicitMatcher(0x0010));

--- a/router/src/main/java/com/chenenyu/router/matcher/RestfulParamsMatcher.java
+++ b/router/src/main/java/com/chenenyu/router/matcher/RestfulParamsMatcher.java
@@ -1,0 +1,102 @@
+package com.chenenyu.router.matcher;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.chenenyu.router.RouteRequest;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Chen
+ * @date 2017/12/9
+ */
+
+public class RestfulParamsMatcher extends AbsExplicitMatcher {
+    private static final String PARAM_VALUE = "([a-zA-Z0-9_#'!+%~,\\-\\.\\@\\$\\:]+)";
+    private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
+    private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";
+    private static final Pattern PARAM_PATTERN = Pattern.compile(PARAM_REGEX);
+
+
+    private Pattern mRegex;
+    private HashMap<String, Set<String>> mRouteParamsMap;
+
+    public RestfulParamsMatcher(int priority) {
+        super(priority);
+        mRouteParamsMap = new HashMap<>();
+    }
+
+    @Override
+    public boolean match(Context context, Uri uri, @Nullable String route, RouteRequest routeRequest) {
+        Uri routerUri = Uri.parse(route);
+        if (mRouteParamsMap.get(route) == null) {
+            mRouteParamsMap.put(route, parseParameters(routerUri));
+        }
+        Set<String> parameters = mRouteParamsMap.get(route);
+        if (parameters == null) {
+            return false;
+        }
+        String schemeHostAndPath = schemeHostAndPath(routerUri);
+        this.mRegex = Pattern.compile(schemeHostAndPath.replaceAll(PARAM_REGEX, PARAM_VALUE) + "$");
+        Iterator<String> paramsIterator = parameters.iterator();
+        Matcher matcher = mRegex.matcher(schemeHostAndPath(uri));
+        int i = 1;
+
+        if (matcher.matches()) {
+            Bundle bundle = routeRequest.getExtras();
+            while (paramsIterator.hasNext()) {
+                String key = paramsIterator.next();
+                String value = matcher.group(i++);
+                if (value != null && !"".equals(value.trim())) {
+                    bundle.putString(key, value);
+                }
+            }
+
+            if (uri.getQuery() != null) {
+                parseParams(uri, routeRequest);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static Set<String> parseParameters(Uri uri) {
+        Matcher matcher = PARAM_PATTERN.matcher(uri.getHost() + getEncodePath(uri));
+        Set<String> patterns = new LinkedHashSet<>();
+        while (matcher.find()) {
+            patterns.add(matcher.group(1));
+        }
+        return patterns;
+    }
+
+    private static String schemeHostAndPath(Uri uri) {
+        return uri.getScheme() + "://" + uri.getHost() + getEncodePath(uri);
+    }
+
+    private static String getEncodePath(Uri uri) {
+        String path = uri.getPath();
+        StringBuilder decodePath = new StringBuilder();
+        if (!TextUtils.isEmpty(path)) {
+            String[] pathArray = path.split("/");
+            for (String temp : pathArray
+                    ) {
+                if (!TextUtils.isEmpty(temp)) {
+                    decodePath.append("/");
+                    decodePath.append(Uri.encode(temp));
+                }
+            }
+        }
+        return decodePath.toString();
+    }
+}
+


### PR DESCRIPTION
新增Restful形式的path参数解析matcher
eg：
在Activity注解如下：
@Route("foo://app/{type}/{name}")

进行Route跳转代码如下：
Router.build("foo://app/send/chen")

获取path参数如下：
getStringExtra("type")、getStringExtra("name");