### PR TITLE
Fix activity start animation

### DIFF
--- a/router/src/main/java/com/chenenyu/router/RealRouter.java
+++ b/router/src/main/java/com/chenenyu/router/RealRouter.java
@@ -382,7 +382,7 @@ class RealRouter extends AbsRouter {
         } else {
             fragment.startActivityForResult(intent, mRouteRequest.getRequestCode(), options);
         }
-        if (activity != null && mRouteRequest.getEnterAnim() != 0 && mRouteRequest.getExitAnim() != 0) {
+        if (activity != null && mRouteRequest.getEnterAnim() != -1 && mRouteRequest.getExitAnim() != -1) {
             // Add transition animation.
             activity.overridePendingTransition(
                     mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());
@@ -415,7 +415,7 @@ class RealRouter extends AbsRouter {
                 fragment.startActivityForResult(intent, mRouteRequest.getRequestCode());
             }
         }
-        if (activity != null && mRouteRequest.getEnterAnim() != 0 && mRouteRequest.getExitAnim() != 0) {
+        if (activity != null && mRouteRequest.getEnterAnim() != -1 && mRouteRequest.getExitAnim() != -1) {
             // Add transition animation.
             activity.overridePendingTransition(
                     mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());

--- a/router/src/main/java/com/chenenyu/router/RealRouter.java
+++ b/router/src/main/java/com/chenenyu/router/RealRouter.java
@@ -346,7 +346,7 @@ class RealRouter extends AbsRouter {
             ActivityCompat.startActivityForResult((Activity) context, intent,
                     mRouteRequest.getRequestCode(), options);
 
-            if (mRouteRequest.getEnterAnim() != -1 || mRouteRequest.getExitAnim() != -1) {
+            if (mRouteRequest.getEnterAnim() >= 0 && mRouteRequest.getExitAnim() >= 0) {
                 // Add transition animation.
                 ((Activity) context).overridePendingTransition(
                         mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());
@@ -382,7 +382,7 @@ class RealRouter extends AbsRouter {
         } else {
             fragment.startActivityForResult(intent, mRouteRequest.getRequestCode(), options);
         }
-        if (activity != null && mRouteRequest.getEnterAnim() != -1 && mRouteRequest.getExitAnim() != -1) {
+        if (activity != null && mRouteRequest.getEnterAnim() >= 0 && mRouteRequest.getExitAnim() >= 0) {
             // Add transition animation.
             activity.overridePendingTransition(
                     mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());
@@ -415,7 +415,7 @@ class RealRouter extends AbsRouter {
                 fragment.startActivityForResult(intent, mRouteRequest.getRequestCode());
             }
         }
-        if (activity != null && mRouteRequest.getEnterAnim() != -1 && mRouteRequest.getExitAnim() != -1) {
+        if (activity != null && mRouteRequest.getEnterAnim() >=0 && mRouteRequest.getExitAnim() >= 0) {
             // Add transition animation.
             activity.overridePendingTransition(
                     mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());

--- a/router/src/main/java/com/chenenyu/router/RealRouter.java
+++ b/router/src/main/java/com/chenenyu/router/RealRouter.java
@@ -346,7 +346,7 @@ class RealRouter extends AbsRouter {
             ActivityCompat.startActivityForResult((Activity) context, intent,
                     mRouteRequest.getRequestCode(), options);
 
-            if (mRouteRequest.getEnterAnim() != 0 && mRouteRequest.getExitAnim() != 0) {
+            if (mRouteRequest.getEnterAnim() != -1 || mRouteRequest.getExitAnim() != -1) {
                 // Add transition animation.
                 ((Activity) context).overridePendingTransition(
                         mRouteRequest.getEnterAnim(), mRouteRequest.getExitAnim());

--- a/router/src/main/java/com/chenenyu/router/RouteRequest.java
+++ b/router/src/main/java/com/chenenyu/router/RouteRequest.java
@@ -36,8 +36,8 @@ public class RouteRequest implements Serializable {
     @Nullable
     private RouteCallback callback;
     private int requestCode = INVALID_REQUEST_CODE;
-    private int enterAnim;
-    private int exitAnim;
+    private int enterAnim = -1;//use -1 to mark use default animation
+    private int exitAnim = -1;
     @Nullable
     private ActivityOptionsCompat activityOptionsCompat;
 

--- a/router/src/main/java/com/chenenyu/router/RouteRequest.java
+++ b/router/src/main/java/com/chenenyu/router/RouteRequest.java
@@ -17,7 +17,7 @@ import java.util.Set;
  */
 @SuppressWarnings("WeakerAccess")
 public class RouteRequest implements Serializable {
-    private static final int INVALID_REQUEST_CODE = -1;
+    private static final int INVALID_CODE = -1;
 
     private Uri uri;
     private Bundle extras;
@@ -35,9 +35,9 @@ public class RouteRequest implements Serializable {
     private Set<String> addedInterceptors;
     @Nullable
     private RouteCallback callback;
-    private int requestCode = INVALID_REQUEST_CODE;
-    private int enterAnim = -1;//use -1 to mark use default animation
-    private int exitAnim = -1;
+    private int requestCode = INVALID_CODE;
+    private int enterAnim = INVALID_CODE;
+    private int exitAnim = INVALID_CODE;
     @Nullable
     private ActivityOptionsCompat activityOptionsCompat;
 
@@ -151,7 +151,7 @@ public class RouteRequest implements Serializable {
 
     public void setRequestCode(int requestCode) {
         if (requestCode < 0) {
-            this.requestCode = INVALID_REQUEST_CODE;
+            this.requestCode = INVALID_CODE;
         } else {
             this.requestCode = requestCode;
         }
@@ -162,7 +162,11 @@ public class RouteRequest implements Serializable {
     }
 
     public void setEnterAnim(int enterAnim) {
-        this.enterAnim = enterAnim;
+        if (enterAnim < 0) {
+            this.enterAnim = INVALID_CODE;
+        } else {
+            this.enterAnim = enterAnim;
+        }
     }
 
     public int getExitAnim() {
@@ -170,7 +174,11 @@ public class RouteRequest implements Serializable {
     }
 
     public void setExitAnim(int exitAnim) {
-        this.exitAnim = exitAnim;
+        if (exitAnim < 0) {
+            this.exitAnim = INVALID_CODE;
+        } else {
+            this.exitAnim = exitAnim;
+        }
     }
 
     @Nullable


### PR DESCRIPTION
1、overridePendingTransition(0,0)，其中的0表示的是无需过渡动画；
2、如果没有调用overridePendingTransition()表示的是使用系统提供的默认过渡动画。
因此不能使用0充当设置标记。

其中一种场景是，启动一个activity，需要从底部弹起：
```
overridePendingTransition(R.anim.enter_from_bottom,0);
```
在Router判断中，因为第二个参数是0，不会走这个动画 ，因此动画无效。

此PR修复了这个问题。