### PR TITLE
transform时清空Records

### DIFF
--- a/gradle-plugin/src/main/groovy/com/chenenyu/router/RouterTransform.groovy
+++ b/gradle-plugin/src/main/groovy/com/chenenyu/router/RouterTransform.groovy
@@ -52,7 +52,7 @@ class RouterTransform extends Transform {
             throws TransformException, InterruptedException, IOException {
         long begin = System.currentTimeMillis()
         project.logger.info("- router transform begin:")
-
+        Scanner.clearRecordsClasses()
         transformInvocation.inputs.each { TransformInput input ->
             if (!input.jarInputs.empty) {
                 project.logger.info("-- jarInputs:")

--- a/gradle-plugin/src/main/groovy/com/chenenyu/router/Scanner.groovy
+++ b/gradle-plugin/src/main/groovy/com/chenenyu/router/Scanner.groovy
@@ -30,6 +30,12 @@ class Scanner {
     private static
     final Set<String> excludeJar = ["com.android.support", "android.arch.", "androidx."]
 
+    static void clearRecordsClasses() {
+        records.forEach { record ->
+            record.aptClasses.clear()
+        }
+    }
+
     static boolean shouldScanJar(JarInput jarInput) {
         excludeJar.each {
             if (jarInput.name.contains(it))


### PR DESCRIPTION
## 解决多Application Module时出现ClassNoFound异常。

### 场景如下：

 在Sample，建立App1的Application Module，运行 App会把AppRouteTable记录到Record.aptClasses。切换运行App1，Knife会把AppRouterTable也写到AptHub中，但是App1是没有AppRouterTable。会出现ClassNoFound。

### 解决方法

在transform时清空Record的aptClasses，重新扫描。